### PR TITLE
Add: data labeling script for Amharic NER task

### DIFF
--- a/notebooks/3_data_labeling.ipynb
+++ b/notebooks/3_data_labeling.ipynb
@@ -1,0 +1,62 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# notebooks/3_data_labeling.ipynb\n",
+    "import pandas as pd\n",
+    "from datasets import Dataset, ClassLabel, Sequence\n",
+    "from transformers import AutoTokenizer\n",
+    "\n",
+    "# Load processed data\n",
+    "df = pd.read_csv(\"../data/processed/telegram_messages_20250621_052911.csv\")\n",
+    "\n",
+    "# Select 50 diverse messages for labeling\n",
+    "sample_df = df.sample(50, random_state=42)\n",
+    "\n",
+    "# After manual labeling, save in CoNLL format\n",
+    "def save_conll(data, filepath):\n",
+    "    with open(filepath, \"w\", encoding=\"utf-8\") as f:\n",
+    "        for item in data:\n",
+    "            for token, label in zip(item[\"tokens\"], item[\"labels\"]):\n",
+    "                f.write(f\"{token}\\t{label}\\n\")\n",
+    "            f.write(\"\\n\")\n",
+    "\n",
+    "# Example structure of labeled data\n",
+    "labeled_data = [\n",
+    "    {\n",
+    "        \"tokens\": [\"ለልጆች\", \"ጫማ\", \"በ\", \"350\", \"ብር\"],\n",
+    "        \"labels\": [\"B-PRODUCT\", \"I-PRODUCT\", \"O\", \"B-PRICE\", \"I-PRICE\"]\n",
+    "    },\n",
+    "    # ... more examples\n",
+    "]\n",
+    "\n",
+    "save_conll(labeled_data, \"data/labeled/amharic_ner.conll\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This PR adds an interactive Jupyter notebook for manually labeling Amharic text messages as part of the Named Entity Recognition (NER) pipeline. The notebook performs the following:
- Loads preprocessed Telegram message data
- Samples a subset of examples for manual annotation
- Defines a labeling structure using the BIO tagging format
- Saves labeled data in CoNLL format for downstream NER training
