### PR TITLE
Add Sample Labeling on Cleaned Telegram Messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,7 @@ __pycache__/
 # Jupyter Notebooks Checkpoints
 .ipynb_checkpoints/
 
-# Colab Notebooks
-*.ipynb
+
 
 # Virtual environment
 env/

--- a/notebooks/3_data_labeling.ipynb
+++ b/notebooks/3_data_labeling.ipynb
@@ -36,6 +36,15 @@
     "\n",
     "save_conll(labeled_data, \"data/labeled/amharic_ner.conll\")"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sample_df.head(50)\n"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
This pull request introduces a manually labeled sample of 50 Telegram messages selected from the processed dataset. Key actions include:

Selected 50 random samples using df.sample(50, random_state=42)

Performed labeling on the cleaned_text field to avoid issues from unstructured symbols (e.g., emojis, special characters)

Ensured that original raw text remains untouched for traceability

Deferred cleaning operations to avoid conflicts with labeling offsets